### PR TITLE
Add an npm package build script and remove README references to Bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Clone this repository, and then execute the following commands within the checko
 $ npm install
 ```
 
-This will use Node's NPM package manager to install all the dependencies for building and testing this library. We use [Bower](http://bower.io) to manage client script dependencies, but Bower script installation is handled as part of the `npm install` command.
+This will use Node's NPM package manager to install all the dependencies for building and testing this library. [Grunt](http://gruntjs.com) is installed automatically by the `npm install` command, and is used to run the build tasks.
 
 
 ### Building
@@ -201,7 +201,7 @@ To update the JavaScript files in after you've made changes, run the library's `
 $ npm run build
 ```
 
-This will use [Grunt](http://gruntjs.com) to check the source script for syntax errors, then minify it to create [the minified angular-wp-api.min.js file](angular-wp-api.min.js) and a corresponding source map file.
+This will use Grunt to check the source script for syntax errors, then minify it to create [the minified angular-wp-api.min.js file](angular-wp-api.min.js) and a corresponding source map file.
 
 
 ### Testing
@@ -211,7 +211,7 @@ Coming soon . .
 
 #### A note on Grunt
 
-The custom "build" and "test" scripts defined in this library's [package.json](package.json) enable access to Grunt's functionality after a simple `npm install`; however, these commands can also be run directly using Grunt itself. In order to gain access to the `grunt` console command, you must globally install the Grunt command-line interface:
+The custom "build" script defined in this library's [package.json](package.json) enable access to Grunt's functionality after a simple `npm install`; however, these commands can also be run directly using Grunt itself. In order to gain access to the `grunt` console command, you must globally install the Grunt command-line interface:
 
 ```bash
 $ npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "angular-wp-api",
   "version": "0.0.1-alpha1",
+  "scripts": {
+    "postinstall": "grunt",
+    "build": "grunt",
+    "watch": "grunt watch"
+  },
   "devDependencies": {
     "bower": "~1.3.3",
     "grunt": "~0.4.2",


### PR DESCRIPTION
Several comments in the WP-API/client-js repo from which this project's README was derived do not fully apply to angular-wp-api: There's no need to use Bower in this case, and the "A Note on Grunt" section was referring to steps which did not exist in this repository.

This PR adds a build script (making the Note on Grunt section and several other comments more accurate), and updates the README to remove references to Bower. Grunt will now automatically run on `npm install`, through a custom postinstall NPM package script command; Grunt is now also aliased to `npm run build`.

Awesome work on this so far, I can't wait to see where it goes!
