### PR TITLE
added bower.json so this plugin is bower available

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "angular-wp-api",
+  "main": "angular-wp-api.js",
+  "version": "0.0.0",
+  "homepage": "https://github.com/jeffsebring/angular-wp-api",
+  "authors": [
+    "Jeff Sebring <jeff@jeffsebring.com>"
+  ],
+  "description": "AngularJS Module for WP-API",
+  "keywords": [
+    "AngularJS",
+    "WordPress",
+    "WP-API"
+  ],
+  "license": "GPLv3",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Hey Jeff,

I added a simple bower.json file so that I can install it in my projects via `bower install angular-wp-api`.

Once merged, either you can `bower register` or I can do it. I'm easy!

Cheers
